### PR TITLE
Update actions/download-artifact from v3 to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: static-site
           path: out/


### PR DESCRIPTION
Fix deprecation warning by upgrading to the latest version of the download-artifact action, maintaining compatibility with upload-artifact@v4 already in use.