### PR TITLE
Fix Docker image build and deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
Changed the SHA tag prefix from {{branch}}- to sha- to prevent invalid tag format errors when the branch variable is not properly resolved. This fixes the error:
ERROR: failed to build: invalid tag 'ghcr.io/floatingman/bigheartedlabs.com:-c61c429': invalid reference format