### PR TITLE
Debug failing deploy to server action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
The previous implementation used echo to write the SSH private key, which doesn't properly preserve newlines in multi-line strings. This caused the SSH key file to be malformed, resulting in authentication failures during deployment.

Changed to use printf '%s\n' which correctly preserves all newlines in the SSH private key, ensuring the key file is properly formatted.

Fixes the "Process completed with exit code 1" error in the Setup SSH step.