### PR TITLE
Fix deploy action workflow issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,17 +87,18 @@ jobs:
           echo "✅ All required secrets are configured"
 
       - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Add known hosts
         run: |
           mkdir -p ~/.ssh
-          cat > ~/.ssh/deploy_key <<'EOF'
-          ${{ secrets.SSH_PRIVATE_KEY }}
-          EOF
-          chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
 
       - name: Pull latest Docker image and restart container
         run: |
-          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} << 'EOF'
+          ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} << 'EOF'
             set -e
             cd ${{ secrets.DEPLOY_PATH }}
 
@@ -118,7 +119,7 @@ jobs:
 
       - name: Verify deployment
         run: |
-          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+          ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
             "cd ${{ secrets.DEPLOY_PATH }} && docker-compose ps bigheartedlabs"
 
       - name: Deployment summary


### PR DESCRIPTION
Replace the heredoc-based SSH key setup with the more reliable webfactory/ssh-agent action. This action properly handles SSH key formatting and ssh-agent configuration, avoiding the formatting issues that were causing the deployment to fail.

Changes:
- Use webfactory/ssh-agent@v0.9.0 for SSH key management
- Separate known_hosts setup into its own step
- Remove -i flag from ssh commands (ssh-agent handles authentication)
- Simplifies SSH configuration and improves reliability