### PR TITLE
Fix missing check-env.js script error

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -57,9 +57,6 @@ Dockerfile
 docker-compose.yml
 .dockerignore
 
-# Scripts
-scripts/
-
 # Backups
 *.backup
 *.bak


### PR DESCRIPTION
The scripts/ directory was being excluded by .dockerignore, which prevented the check-env.js script from being copied into the Docker image. This caused the preexport npm script to fail during the build.

Removed the scripts/ exclusion from .dockerignore so the check-env.js script is available during the Docker build process.

Fixes #15