### PR TITLE
Run GitHub Action only after PR merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
- Build job now runs on both PRs and pushes for validation
- Docker images are only pushed to registry when PR is merged (push event)
- Deploy job continues to only run on main/master branches
- This saves registry storage and ensures PRs are validated before merge